### PR TITLE
Change death message mute to apply for current user

### DIFF
--- a/src/main/java/joshdev/muteDeaths/MuteDeaths.java
+++ b/src/main/java/joshdev/muteDeaths/MuteDeaths.java
@@ -3,6 +3,7 @@ package joshdev.muteDeaths;
 
 import io.papermc.paper.command.brigadier.CommandSourceStack;
 import joshdev.muteDeaths.events.PlayerDeath;
+import joshdev.muteDeaths.events.PlayerJoin;
 import org.bukkit.NamespacedKey;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.incendo.cloud.annotations.AnnotationParser;
@@ -34,6 +35,8 @@ public final class MuteDeaths extends JavaPlugin {
     }
     // Register death event.
     getServer().getPluginManager().registerEvents(new PlayerDeath(), this);
+    // Register join event to send a reminder if player is muted.
+    getServer().getPluginManager().registerEvents(new PlayerJoin(), this);
     // Ready message
     getLogger().info("MuteDeaths is good to go!");
   }

--- a/src/main/java/joshdev/muteDeaths/commands/MuteCommand.java
+++ b/src/main/java/joshdev/muteDeaths/commands/MuteCommand.java
@@ -18,13 +18,15 @@ import org.incendo.cloud.annotations.processing.CommandContainer;
 @CommandContainer
 public class MuteCommand {
 
-  private final TextComponent MUTE_ON =
-      Component.text("Death message are now muted.", NamedTextColor.GREEN);
+  private static final TextComponent MUTE_ON =
+          Component.text("✔ ", NamedTextColor.DARK_GREEN)
+                  .append(Component.text("Your death messages are now muted.", NamedTextColor.GREEN));
 
-  private final TextComponent MUTE_OFF =
-      Component.text("Death message are now unmuted.", NamedTextColor.GREEN);
+  private static final TextComponent MUTE_OFF =
+          Component.text("✖ ", NamedTextColor.RED)
+                  .append(Component.text("Your death messages are now visible to others.", NamedTextColor.GREEN));
 
-  private final TextComponent ERROR_MESSAGE =
+  private static final TextComponent ERROR_MESSAGE =
       Component.text(
           "An error occurred while trying to mute death messages. Please contact the server manager.",
           NamedTextColor.RED);

--- a/src/main/java/joshdev/muteDeaths/events/PlayerDeath.java
+++ b/src/main/java/joshdev/muteDeaths/events/PlayerDeath.java
@@ -2,7 +2,7 @@
 package joshdev.muteDeaths.events;
 
 import joshdev.muteDeaths.MuteDeaths;
-import net.kyori.adventure.text.Component;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.PlayerDeathEvent;
@@ -13,33 +13,14 @@ public class PlayerDeath implements Listener {
 
   @EventHandler
   public void onPlayerDeath(PlayerDeathEvent event) {
-    Component deathMessage = event.deathMessage();
-    event.deathMessage(null);
-    MuteDeaths.pluginInstance
-        .getServer()
-        .getOnlinePlayers()
-        .forEach(
-            player -> {
-              PersistentDataContainer playerContainer = player.getPersistentDataContainer();
-              if (playerContainer.has(MuteDeaths.MUTE_KEY, PersistentDataType.BOOLEAN)) {
-                try {
-                  boolean playerToggle =
-                      playerContainer.get(MuteDeaths.MUTE_KEY, PersistentDataType.BOOLEAN);
-                  if (!playerToggle) {
-                    if (deathMessage != null) {
-                      player.sendMessage(deathMessage);
-                    }
-                  }
-                } catch (NullPointerException exc) {
-                  MuteDeaths.pluginInstance
-                      .getLogger()
-                      .warning("Couldn't get death message for player " + player.getName());
-                }
-              } else {
-                if (deathMessage != null) {
-                  player.sendMessage(deathMessage);
-                }
-              }
-            });
+    Player player = event.getPlayer();
+    PersistentDataContainer playerContainer = player.getPersistentDataContainer();
+
+    Boolean isMuted = playerContainer.get(MuteDeaths.MUTE_KEY, PersistentDataType.BOOLEAN);
+
+    if (Boolean.TRUE.equals(isMuted)) {
+      // Cancel death message if player is muted.
+      event.deathMessage(null);
+    }
   }
 }


### PR DESCRIPTION
Now when a user mutes death message it will mute deaths for the player running the command. Also added reminder and changed the texts a bit